### PR TITLE
長い音のデコードが正しくない事があった問題を修正しました。

### DIFF
--- a/part.c
+++ b/part.c
@@ -11,7 +11,7 @@
  */
 int read_notes(struct pmd* pmd, uint8_t** pp)
 {
-    uint8_t n;
+    int n;
     while(1) {
         if(pmd->return_addr != 0
            && (*pp - pmd->buffer) == pmd->return_addr) {


### PR DESCRIPTION
再現方法:
echo A T100@0o4c%300 > test.mml
mucc test.mml test.pmd
demucc test.pmd

修正前: A T100@0o4c%44
修正後: A T100@0o4c%300
